### PR TITLE
Handle non standard ABSPATH for assets

### DIFF
--- a/src/Hametuha/StringUtility/Path.php
+++ b/src/Hametuha/StringUtility/Path.php
@@ -20,7 +20,9 @@ trait Path {
 	 * @return string URL.
 	 */
 	public function path_to_url( $path ) {
-		if ( false !== strpos( $path, ABSPATH ) ) {
+		if ( false !== strpos( $path, WP_CONTENT_DIR ) ) {
+			return str_replace( WP_CONTENT_DIR, WP_CONTENT_URL, $path );
+		} elseif ( false !== strpos( $path, ABSPATH ) ) {
 			return str_replace( ABSPATH, home_url( '/' ), $path );
 		} else {
 			return $path;


### PR DESCRIPTION
Some WordPress installs have a directory structure like the following:

```
/
/wp-config.php
/index.php
/wordpress   # main WordPress install is here
/content     # custom content directory
```
In this case `ABSPATH` will be set to `/wordpress` - if the asset file is located under the custom content directory then the `false !== strpos( $path, ABSPATH )` check will fail and the unmodified path will be returned.

It'd be good to check that `$path` is definitely a URL before returning it too.